### PR TITLE
Adding CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Getting Started
+
+We're open to contributions to our documentation:
+
+* in the form of feedback via issues or
+* in the form of content changes via pull requests.
+
+To initiate a contribution, we recommend that you start from the corresponding documentation page on the SAP Help Portal, and use the appropriate links in the menu bar.
+
+## Guidelines
+
+Please ensure you read and follow the [Contribution Guidelines](https://help.sap.com/products/open-documentation-initiative/contribution-guidelines/readme.html) before submitting your first contribution.
+
+## Developer Certificate of Origin (DCO)
+
+In the context of content contribution, you need to sign a Developer's Certificate of Origin (DCO) when you create your first pull request to this project. Following the [Contributor License Agreement Process](https://help.sap.com/products/open-documentation-initiative/contribution-guidelines/cla.html), the CLA assistant is used to automate this process. 


### PR DESCRIPTION
As discussed with @SebastianWolf-SAP, let's use a central `CONTRIBUTING.md` as the minimum for all documentation repositories.