### PR TITLE
Remove outdated information about internal mirror repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,3 @@
 This repository contains the [default community files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for a SAP organization on GitHub.
 
 These files are used by all public repositories if there are no own versions of these health files configured.
-
-Changes to the community health files and this repository are managed in a central internal location and mirrored to this repository.
-Manual changes to this repository will be overwritten and we can not accept any pull requests.


### PR DESCRIPTION
Hi @Shegox,

if the mirror approach is no longer used, we should maybe update the README.

Cheers,
Jens